### PR TITLE
Meta data changing default page

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -4,7 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>su grade analytics</title>
+    <meta charset="UTF-8">
+    <meta name="description" content="Grade distribution and reviews for courses and professors at Salisbury University.">
+    <meta name="keywords" content="Salisbury, Grades, Distribution, Courses, Professors, Analytics">
+    <title>salisbury analytics</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.4/flowbite.min.css"  rel="stylesheet" />
     <link rel="icon" sizes="32x32" href="{{ URL::asset('bar_chart_logo.jpg') }}" type="image/x-icon"/>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -9,7 +9,7 @@
     <a href="{{route("professors.index")}}" class=" inline-block decoration-yellow-500 decoration-4 hover:underline px-5 py-2 rounded-lg bold ">all professors</a>
     <a href="{{route("courses.index")}}" class=" inline-block decoration-yellow-500 decoration-4 hover:underline px-5 py-2 rounded-lg bold ">all courses</a>
     <a href="{{route("reviews.create")}}" class=" inline-block decoration-yellow-500 decoration-4 hover:underline px-5 py-2 rounded-lg bold ">add review</a> 
-    <a class=" inline-block hover:underline px-5 py-2 decoration-yellow-500 decoration-4 rounded-lg font-bold " href="/">about</a>
+    <a class=" inline-block hover:underline px-5 py-2 decoration-yellow-500 decoration-4 rounded-lg font-bold " href="/about">about</a>
 
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ use App\Http\Controllers\ProfessorController;
 |
 */
 
-Route::get('/', function () {
+Route::get('/about', function () {
 
     $usage_log=UsageLog::whereDate('created_at', now())->first();
     $usage_log->about_views++;
@@ -30,6 +30,7 @@ Route::get('/', function () {
 });
 
 //routes for courses
+Route::get('/', [CourseController::class,"index"]);
 Route::resource('courses',CourseController::class);
 
 //crud review routes


### PR DESCRIPTION
This change will add meat tags for seo and changes the default page from about to courses. I want to display what I think will be most interesting first. The about page is more ancillary and should not be the default.